### PR TITLE
Fix for some memory corruption in libg15render

### DIFF
--- a/libg15render/src/pixel.c
+++ b/libg15render/src/pixel.c
@@ -395,7 +395,12 @@ g15r_loadWbmpSplash(g15canvas *canvas, char *filename)
                              &width,
                              &height);
 
-    memcpy (canvas->buffer, buf, G15_BUFFER_LEN);
+    int byte_width = width / 8;
+    if (width %8)
+        byte_width++;
+    
+    memcpy (canvas->buffer, buf, byte_width * height);
+    free(buf);
     return 0;
 }
 

--- a/libg15render/src/text.c
+++ b/libg15render/src/text.c
@@ -330,26 +330,17 @@ g15font * g15r_loadG15Font(char *filename) {
 
     font->numchars = buffer[12] | (buffer[13] << 8);
     font->default_gap = buffer[14];
-    unsigned int current_alloc = 2048;
-    char *glyphBuf =  malloc(current_alloc);
-    char *glyphPtr = glyphBuf;
-    unsigned int memsize=0;
     for (i=0;i <font->numchars; i++) {
         unsigned char charheader[G15_CHAR_HEADER_SIZE];
         unsigned int character;
         fread(charheader, G15_CHAR_HEADER_SIZE, 1, file);
         character = charheader[0] | (charheader[1] << 8);
         font->glyph[character].width = charheader[2] | (charheader[3] << 8);
-        memsize+=(font->font_height * ((font->glyph[character].width + 7) / 8));
-        if(memsize>current_alloc) { /* attempt to semi-coherently allocate additional memory */
-            current_alloc+=((font->font_height * ((font->glyph[character].width + 7) / 8)*(font->numchars - i)));
-            glyphBuf = realloc(glyphBuf,(size_t)current_alloc);
-        }
-        font->glyph[character].buffer = (unsigned char*)glyphPtr;
+        size_t glyphMemSize = (font->font_height * ((font->glyph[character].width + 7) / 8));
+        font->glyph[character].buffer = malloc(glyphMemSize);
         font->glyph[character].gap = 0;
-        fread(font->glyph[character].buffer, font->font_height * ((font->glyph[character].width + 7) / 8), 1, file);
+        fread(font->glyph[character].buffer, glyphMemSize, 1, file);
         font->active[character] = 1;
-        glyphPtr+=(font->font_height * ((font->glyph[character].width + 7) / 8));
     }
 
     fclose(file);


### PR DESCRIPTION
There are some memory corruption errors in libg15render which made it a lucky game whether the g15daemon crashes or not when compiling it from source. Especially writing to freed memory in g15r_loadWbmpSplash seems to be a problem.

I decided to share the fix for the libg15render library, but as the original SVN repo from SourceForge is dead since 2011, I instead want to push it to your GitHub repository. I'm not sure if you accept these kind of modifications as you only mirror the SVN upstream, but if not, I'll leave my fork anyways for reference.